### PR TITLE
Use cronjob/job.failed && update labels, counters, status components

### DIFF
--- a/.changelog/6.txt
+++ b/.changelog/6.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+Display pods with containers waiting when errored. Use cronjob/job.failed && update labels, counters, status components
+```

--- a/src/components/CronJob.vue
+++ b/src/components/CronJob.vue
@@ -1,21 +1,21 @@
 <style scoped>
 .BorderGrid {
-    display: table;
-    width: 100%;
-    margin-top: -16px;
-    margin-bottom: -16px;
-    table-layout: fixed;
-    border-collapse: collapse;
-    border-style: hidden;
+  display: table;
+  width: 100%;
+  margin-top: -16px;
+  margin-bottom: -16px;
+  table-layout: fixed;
+  border-collapse: collapse;
+  border-style: hidden;
 }
 
 .BorderGrid-row {
-    display: table-row;
+  display: table-row;
 }
 
 .BorderGrid-cell {
-    display: table-cell;
-    border: 1px solid rgb(214,207,222);
+  display: table-cell;
+  border: 1px solid rgb(214,207,222);
 }
 
 .BorderGrid--spacious {
@@ -24,8 +24,8 @@
 }
 
 .BorderGrid--spacious .BorderGrid-cell {
-    padding-top: 24px;
-    padding-bottom: 24px;
+  padding-top: 24px;
+  padding-bottom: 24px;
 }
 </style>
 

--- a/src/components/CronJobRow.vue
+++ b/src/components/CronJobRow.vue
@@ -49,10 +49,10 @@
             <Octicon name="x-circle-fill" /> {{ lux1(lastFailureTime) }}
           </span>
 
-          <template v-if="lastSuccedded">
+          <template v-if="lastSucceeded">
             <span class="mr-2"><Octicon name="calendar" /> {{ lux1(cronJob.lastsuccessfultime) }}</span>
             <span class="mr-2">
-              <Octicon name="goal" /> Completed {{ lux1(lastSuccedded.status.completiontime) }}
+              <Octicon name="goal" /> {{ luxs(lastSucceeded.status.completiontime.seconds) }}
             </span>
           </template>
         </template>
@@ -78,6 +78,9 @@ export default {
   name: 'CronJobRow',
   props: ['cronJob'],
   methods: {
+    luxs(t) {
+      return DateTime.fromSeconds(t).toRelative();
+    },
     lux1(t) {
       return DateTime.fromISO(t).toRelative();
     },
@@ -147,7 +150,7 @@ export default {
 
       return null;
     },
-    lastSuccedded() {
+    lastSucceeded() {
       const sgt = this.succeeded;
       if (sgt.length > 0) {
         return sgt[sgt.length - 1];
@@ -156,14 +159,17 @@ export default {
       return null;
     },
     showLastFailure() {
-      if (this.lastSuccedded && this.lastFailed) {
+      var lastTransitionTime;
+      if (this.lastSucceeded && this.lastFailed) {
+          const possible = this.lastFailed;
           if (this.lastFailed.failure_condition) {
-              const lastTransitionTime = this.lastFailed.failure_condition.lastTransitionTime;
+            lastTransitionTime = this.lastFailed.failure_condition.lastTransitionTime;
           } else {
-              const target = this.terminationreasonsList.find((first) => first).terminationdetails.finishedat.seconds;
-              const lastTransitionTime = DateTime.fromSeconds(target);
+            const target = possible.terminationreasonsList.find((first) => first).terminationdetails.finishedat.seconds;
+
+            lastTransitionTime = DateTime.fromSeconds(target);
           }
-        const completionTime = this.lastSuccedded.status.completion_time;
+        const completionTime = this.lastSucceeded.status.completion_time;
 
         return lastTransitionTime > completionTime;
       }

--- a/src/components/CronjobRowLabels.vue
+++ b/src/components/CronjobRowLabels.vue
@@ -2,6 +2,8 @@
   <!-- https://primer.style/css/components/labels#labels -->
   <span class="Label Label--accent Label--inline mr-1" v-if="active">Active</span>
   <span class="Label Label--secondary Label--inline mr-1" v-if="suspended">Success</span>
+  <span class="Label Label--danger Label--inline mr-1" v-if="failed">Failed</span>
+  <span class="Label Label--danger Label--inline mr-1" v-if="failing">Failing</span>
 </template>
 
 <script>
@@ -10,10 +12,16 @@ export default {
   props: ['cronjob'],
   computed: {
     active(_vm) {
-      return this.cronjob.active;
+      return this.cronjob.active && !this.cronjob.failed;
     },
     suspended(_vm) {
       return this.cronjob.spec.suspend;
+    },
+    failed(_vm) {
+      return this.cronjob.failed && !this.cronjob.active;
+    },
+    failing(_vm) {
+      return this.cronjob.active && this.cronjob.failed;
     },
   },
 };

--- a/src/components/JobCounter.vue
+++ b/src/components/JobCounter.vue
@@ -20,7 +20,7 @@ export default {
       this.jobs.forEach((job) => {
         if (job.succeeded) {
           m.succeeded += 1;
-        } else if (job.status.failed > 0) {
+        } else if (job.status.failed > 0 || job.failed) {
           m.failed += 1;
         } else if (job.status.active > 0) {
           m.active += 1;

--- a/src/components/JobRow.vue
+++ b/src/components/JobRow.vue
@@ -22,7 +22,7 @@
     <div class="color-fg-muted f6 mt-2">
       <StatusProp :propText="status" />
 
-      <span class="mr-2"><Octicon name="stack" />{{ job.spec.completions }}</span>
+      <span class="mr-2"><Octicon name="stack" /> {{ job.spec.completions }}</span>
       <span class="mr-2"><Octicon name="versions" /> {{ job.spec.parallelism }}</span>
       <span class="mr-2"><Octicon name="strikethrough" /> {{ job.spec.suspend }}</span>
       <span class="mr-2"><Octicon name="sparkle-fill" /> {{ luxs(job.status.starttime.seconds) }}</span>

--- a/src/components/JobRow.vue
+++ b/src/components/JobRow.vue
@@ -8,7 +8,9 @@
         </p>
 
         <p class="color-fg-muted mb-0 wb-break-word" v-if="job.failed" v-for="(tl, index) in job.terminationreasonsList">
-          Container {{ tl.containername }} Error: {{ tl.terminationdetails.reason }} - {{ tl.terminationdetails.exitcode }}
+          Error: {{ tl.terminationdetails.reason }} - {{ tl.terminationdetails.exitcode }}<br/>
+          Message: {{ tl.terminationdetails.message }}<br/>
+          Container: {{ tl.containername }}
         </p>
       </div>
 

--- a/src/components/Overview.vue
+++ b/src/components/Overview.vue
@@ -135,7 +135,7 @@ export default {
       this.cronJob.jobsList.forEach((job) => {
         if (job.succeeded) {
           m.succeeded += 1;
-        } else if (job.status.failed > 0) {
+        } else if (job.status.failed > 0 || job.failed) {
           m.failed += 1;
         } else if (job.status.active > 0) {
           m.active += 1;

--- a/src/components/PodRow.vue
+++ b/src/components/PodRow.vue
@@ -8,15 +8,17 @@
           Uuid: {{ pod.uid }}
         </p>
 
-        <p class="color-fg-muted mb-0 wb-break-word" v-for="(tl, index) in pod.terminationreasonsList">
-          Container {{ tl.containername }} Error: {{ tl.terminationdetails.reason }} - {{ tl.terminationdetails.exitcode }}
+        <p class="color-fg-muted mb-0 wb-break-word" v-for="(tr, index) in pod.terminationreasonsList">
+          Error: {{ tr.terminationdetails.reason }} - {{ tr.terminationdetails.exitcode }}<br/>
+          Message: {{ tr.terminationdetails.message }}<br/>
+          Container: {{ tr.terminationdetails.containername }}
         </p>
       </div>
 
       <PodModal :pod="pod" />
     </div>
 
-    <div class="color-fg-muted f6  mt-2">
+    <div class="color-fg-muted f6 mt-2">
       <StatusProp :propText="status" />
 
       <span class="mr-2"><Octicon name="sparkle-fill" /> {{ luxs(pod.startTime) }}</span>
@@ -43,12 +45,16 @@ export default {
       const statusKey = statusState[0];
 
       if (statusKey === 'running' || statusKey == 'waiting') {
+        if (reason && reason.toLowerCase().includes('error')) {
+          return 'Failing';
+        }
+
         return 'Active';
       }
-      if (reason === 'Error') {
+      if (reason && reason.toLowerCase().includes('error')) {
         return 'Failed';
       }
-      if (reason == 'Completed') {
+      if (reason && reason == 'Completed') {
         return 'Succeeded';
       }
     },

--- a/src/components/PodRow.vue
+++ b/src/components/PodRow.vue
@@ -51,7 +51,7 @@ export default {
 
         return 'Active';
       }
-      if (reason && reason.toLowerCase().includes('error')) {
+      if (reason && reason.toLowerCase().includes('error') || this.pod.failed) {
         return 'Failed';
       }
       if (reason && reason == 'Completed') {
@@ -65,7 +65,7 @@ export default {
       if (statusKey === 'running') {
         return 'Box-row--active';
       }
-      if (reason === 'Error') {
+      if (reason && reason.toLowerCase().includes('error') || this.pod.failed) {
         return 'Box-row--danger';
       }
       if (reason == 'Completed') {

--- a/src/components/ProgressBar.vue
+++ b/src/components/ProgressBar.vue
@@ -43,10 +43,10 @@ export default {
       this.cronJob.jobsList.forEach((job) => {
         if (job.succeeded) {
           container.success += 100;
+        } else if (job.status.failed > 0 || job.failed) {
+          container.failed += 100;
         } else if (job.status.active > 0) {
           container.active += 100;
-        } else if (job.status.failed > 0) {
-          container.failed += 100;
         }
       });
 

--- a/src/components/RowLabels.vue
+++ b/src/components/RowLabels.vue
@@ -4,6 +4,7 @@
   <span class="Label mr-1 Label--success Label--inline" v-if="job.succeeded">Success</span>
   <span class="Label mr-1 Label--done Label--inline" v-if="job.succeeded">Done</span>
   <span class="Label mr-1 Label--danger Label--inline" v-if="failed">Failed</span>
+  <span class="Label mr-1 Label--danger Label--inline" v-if="failing">Failing</span>
 </template>
 
 <script>
@@ -12,10 +13,13 @@ export default {
   props: ['job'],
   computed: {
     active(_vm) {
-      return this.job.status.active > 0;
+      return this.job.status.active > 0 && !(this.job.status.failed > 0 || this.job.failed);
     },
     failed(_vm) {
       return this.job.status.failed > 0;
+    },
+    failing(_vm) {
+      return this.job.status.active > 0 && (this.job.status.failed > 0 || this.job.failed);
     },
   },
 };

--- a/src/components/WiderHeader.vue
+++ b/src/components/WiderHeader.vue
@@ -5,7 +5,7 @@
       <div class="d-flex flex-wrap flex-justify-end mb-3  px-3 px-md-4 px-lg-5" style="gap: 1rem;">
         <div class="flex-auto min-width-0 width-fit mr-3">
           <div class=" d-flex flex-wrap flex-items-center wb-break-word f3 text-normal">
-            <Octicon name="repo" />
+            <Octicon name="repo" class="mr-2" />
             <span class="author flex-self-stretch" itemprop="author">
 
               <router-link :to="{ name: 'home' }">

--- a/src/components/protos/sk8l_pb.js
+++ b/src/components/protos/sk8l_pb.js
@@ -4114,7 +4114,8 @@ proto.sk8l.CronjobResponse.toObject = function(includeInstance, msg) {
     proto.sk8l.PodResponse.toObject, includeInstance),
     lastduration: jspb.Message.getFieldWithDefault(msg, 15, 0),
     currentduration: jspb.Message.getFieldWithDefault(msg, 16, 0),
-    spec: (f = msg.getSpec()) && k8s_io_api_batch_v1_generated_pb.CronJobSpec.toObject(includeInstance, f)
+    spec: (f = msg.getSpec()) && k8s_io_api_batch_v1_generated_pb.CronJobSpec.toObject(includeInstance, f),
+    failed: jspb.Message.getBooleanFieldWithDefault(msg, 18, false)
   };
 
   if (includeInstance) {
@@ -4221,6 +4222,10 @@ proto.sk8l.CronjobResponse.deserializeBinaryFromReader = function(msg, reader) {
       var value = new k8s_io_api_batch_v1_generated_pb.CronJobSpec;
       reader.readMessage(value,k8s_io_api_batch_v1_generated_pb.CronJobSpec.deserializeBinaryFromReader);
       msg.setSpec(value);
+      break;
+    case 18:
+      var value = /** @type {boolean} */ (reader.readBool());
+      msg.setFailed(value);
       break;
     default:
       reader.skipField();
@@ -4363,6 +4368,13 @@ proto.sk8l.CronjobResponse.serializeBinaryToWriter = function(message, writer) {
       17,
       f,
       k8s_io_api_batch_v1_generated_pb.CronJobSpec.serializeBinaryToWriter
+    );
+  }
+  f = message.getFailed();
+  if (f) {
+    writer.writeBool(
+      18,
+      f
     );
   }
 };
@@ -4757,6 +4769,24 @@ proto.sk8l.CronjobResponse.prototype.clearSpec = function() {
  */
 proto.sk8l.CronjobResponse.prototype.hasSpec = function() {
   return jspb.Message.getField(this, 17) != null;
+};
+
+
+/**
+ * optional bool failed = 18;
+ * @return {boolean}
+ */
+proto.sk8l.CronjobResponse.prototype.getFailed = function() {
+  return /** @type {boolean} */ (jspb.Message.getBooleanFieldWithDefault(this, 18, false));
+};
+
+
+/**
+ * @param {boolean} value
+ * @return {!proto.sk8l.CronjobResponse} returns this
+ */
+proto.sk8l.CronjobResponse.prototype.setFailed = function(value) {
+  return jspb.Message.setProto3BooleanField(this, 18, value);
 };
 
 


### PR DESCRIPTION
Resources have to be displayed on a failing state when `cronjob.failed`/`job.failed` is set.