### PR TITLE
Release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
-## v0.5.0 (February 01, 2024)
-Generating changelog for release-v0.5.0 from v0.4.0...
+## v0.6.0 (February 16, 2024)
 
+IMPROVEMENTS:
+
+* Display pods with containers waiting when errored. Use cronjob/job.failed && update labels, counters, status components [[GH-6](https://github.com/danroux/sk8l-ui/issues/6)]
+* security: Upgrade vulnerable dependencies, migrate to vite, connectrpc [[GH-7](https://github.com/danroux/sk8l-ui/issues/7)]
+
+## v0.5.0 (February 01, 2024)
 
 IMPROVEMENTS:
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ help: ## This help.
 
 # Bump these on release
 VERSION_MAJOR ?= 0
-VERSION_MINOR ?= 5
+VERSION_MINOR ?= 6
 VERSION_PATCH ?= 0
 
 WITHOUT ?= $(VERSION_MAJOR).$(VERSION_MINOR).$(VERSION_PATCH)


### PR DESCRIPTION
## v0.6.0 

IMPROVEMENTS:

* Display pods with containers waiting when errored. Use cronjob/job.failed && update labels, counters, status components [[GH-6](https://github.com/danroux/sk8l-ui/issues/6)]
* security: Upgrade vulnerable dependencies, migrate to vite, connectrpc [[GH-7](https://github.com/danroux/sk8l-ui/issues/7)]