### PR TITLE
Display json file to create Grafana Dashboard for cronjobs

### DIFF
--- a/.changelog/11.txt
+++ b/.changelog/11.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+grafana: Display json file that can be imported into Grafana to create a base Dashboard.
+```

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ help: ## This help.
 
 # Bump these on release
 VERSION_MAJOR ?= 0
-VERSION_MINOR ?= 6
+VERSION_MINOR ?= 7
 VERSION_PATCH ?= 0
 
 WITHOUT ?= $(VERSION_MAJOR).$(VERSION_MINOR).$(VERSION_PATCH)

--- a/index.html
+++ b/index.html
@@ -15,9 +15,6 @@
     <link id="theme-style" rel="stylesheet" href="/assets/css/modal.vue.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/uplot@1.6/dist/uPlot.min.css">
 
-    <!-- https://www.jsdelivr.com/package/npm/uplot -->
-    <script src="https://cdn.jsdelivr.net/npm/uplot@1.6/dist/uPlot.iife.min.js"></script>
-
     <link href="https://unpkg.com/@primer/css@21.0.9/dist/primer.css" rel="stylesheet" />
     <link href="https://unpkg.com/@primer/octicons/build/build.css" rel="stylesheet" />
     <script type="module" src="/src/main.js"></script>

--- a/src/components/CronjobListHeader.vue
+++ b/src/components/CronjobListHeader.vue
@@ -27,7 +27,7 @@
         <div class="width-full d-flex position-relative container-xl">
           <ul class="list-style-none UnderlineNav-body width-full p-responsive overflow-hidden">
             <li data-tab-item="org-header-overview-tab" class="d-flex js-responsive-underlinenav-item">
-              <a class="UnderlineNav-item selected" href="/primer">
+              <a class="UnderlineNav-item selected" href="#">
                 <Octicon name="home" class="UnderlineNav-octicon" />
                 Overview
               </a>
@@ -38,6 +38,10 @@
               Cronjobs
               <span title="Not available" data-view-component="true" class="Counter js-profile-repository-count">{{ cronjobsLength }}</span>
             </li>
+
+            <li data-tab-item="org-header-repositories-tab" class="d-flex js-responsive-underlinenav-item">
+              <DashboardAnnotationsModal text="Dashboard" />
+            </li>
           </ul>
         </div>
       </nav>
@@ -47,6 +51,7 @@
 
 <script>
 import Octicon from '@/components/Octicon.vue';
+import DashboardAnnotationsModal from '@/components/DashboardAnnotationsModal.vue';
 
 export default {
   name: 'CronjobListHeader',
@@ -62,6 +67,7 @@ export default {
   },
   components: {
     Octicon,
+    DashboardAnnotationsModal,
   },
 };
 </script>

--- a/src/components/CronjobModal.vue
+++ b/src/components/CronjobModal.vue
@@ -41,7 +41,6 @@ export default {
   },
   methods: {
     getCronjobYAML: async function(namespace, name) {
-      // simple unary call
       var request = new CronjobRequest({ cronjobName: name, cronjobNamespace: namespace });
       const that = this;
 

--- a/src/components/DashboardAnnotationsModal.vue
+++ b/src/components/DashboardAnnotationsModal.vue
@@ -1,0 +1,95 @@
+<style scoped>
+  button {
+    border: 0px;
+    line-height: 0px;
+    padding: 0px 4px;
+  }
+</style>
+
+<template>
+  <ModalContainer :show-modal="showDashboardAnnotationsModal"
+                  :body="modalBody"
+                  :modal-header="modalHeader"
+                  @close-modal="closeDashboardAnnotationsModal()">
+
+    <template #headerActionContent>
+      <button type="button" class="btn btn-sm" name="button" @click="copyDashboardAnnotations()">
+        <Octicon name="copy" />
+      </button>
+    </template>
+
+    <template #actionElement>
+      <a class="UnderlineNav-item" href="#" @click="getDashboardAnnotations()">
+        <button type="button" class="btn btn-sm" name="button"  >
+          <Octicon name="graph" class="UnderlineNav-octicon" />
+        </button>
+        {{ text }}
+      </a>
+    </template>
+  </ModalContainer>
+</template>
+
+<script>
+import ModalContainer from '@/components/ModalContainer.vue';
+import Octicon from '@/components/Octicon.vue';
+
+import {DashboardAnnotationsRequest,
+       DashboardAnnotationsResponse} from '@/components/protos/sk8l_pb.ts';
+import Sk8lCronjobClient from '@/components/Sk8lCronjobClient.js';
+
+export default {
+  name: 'DashboardAnnotationsModal',
+  props: ['text'],
+  data() {
+    return {
+      showDashboardAnnotationsModal: false,
+      modalBody: "",
+      modalHeader: "",
+    };
+  },
+  methods: {
+    copyDashboardAnnotations: async function() {
+      var request = new DashboardAnnotationsRequest({});
+      const that = this;
+
+      await Sk8lCronjobClient.getDashboardAnnotations(
+        request,
+        (err, response) => {
+          if (!err) {
+            console.log("dali");
+            navigator.clipboard.writeText(response.annotations);
+          } else {
+            console.log(`Unexpected error for getDashboardAnnotations: code = ${err.code}` +
+            `, message = "${err.message}"`);
+          }
+        }
+      );
+    },
+    getDashboardAnnotations: async function() {
+      var request = new DashboardAnnotationsRequest({});
+      const that = this;
+
+      await Sk8lCronjobClient.getDashboardAnnotations(
+        request,
+        (err, response) => {
+          if (!err) {
+            that.modalBody = response.annotations;
+            that.modalHeader = `sk8l-grafana-annotations.json`;
+          } else {
+            console.log(`Unexpected error for getDashboardAnnotations: code = ${err.code}` +
+            `, message = "${err.message}"`);
+          }
+        }
+      );
+      this.showDashboardAnnotationsModal = true;
+    },
+    closeDashboardAnnotationsModal() {
+      this.showDashboardAnnotationsModal = false;
+    },
+  },
+  components: {
+    ModalContainer,
+    Octicon,
+  },
+}
+</script>

--- a/src/components/JobModal.vue
+++ b/src/components/JobModal.vue
@@ -41,7 +41,6 @@ export default {
   },
   methods: {
     getJobYAML: async function(jobNamespace, jobName) {
-      // simple unary call
       var request = new JobRequest({ jobNamespace: jobNamespace, jobName: jobName });
       const that = this;
 

--- a/src/components/Modal.vue
+++ b/src/components/Modal.vue
@@ -71,6 +71,7 @@
 
               <div class="col-1 d-table-cell">
                 <div slot="top-right" style="text-align: right;">
+                  <slot name="headerActionContent"></slot>
                   <button @click="$emit('close')">
                     <Octicon name="x" />
                   </button>

--- a/src/components/ModalContainer.vue
+++ b/src/components/ModalContainer.vue
@@ -6,12 +6,13 @@
   </slot>
 
   <Teleport to="body">
-    <!-- use the modal component, pass in the prop -->
     <Modal :show="showModal" @close="$emit('closeModal')">
-        <template #header>
-          <span>{{ modalHeader }}</span>
-        </template>
-
+      <template #header>
+        <span>{{ modalHeader }}</span>
+      </template>
+      <template #headerActionContent>
+        <slot name="headerActionContent"></slot>
+      </template>
     </Modal>
   </Teleport>
 </template>
@@ -24,7 +25,7 @@ import Octicon from '@/components/Octicon.vue';
 export default {
   name: 'ModalContainer',
   emits: ['closeModal'],
-  props: ['showModal', 'body', 'modalHeader'],
+  props: ['showModal', 'body', 'modalHeader', 'headerActionContent'],
   provide() {
     return {
       body: computed(() => this.body),

--- a/src/components/Overview.vue
+++ b/src/components/Overview.vue
@@ -20,12 +20,6 @@
 
             <div class="col-12 col-md-1 float-left">
               <CronjobModal :cronjob="cronJob" />
-
-              <div class="float-right px-2">
-                <a href="#graph" class="color-fg-muted">
-                  <Octicon name="graph" />
-                </a>
-              </div>
             </div>
           </div>
         </div>

--- a/src/components/PodModal.vue
+++ b/src/components/PodModal.vue
@@ -41,7 +41,6 @@ export default {
   },
   methods: {
     getPodYAML: async function(podNamespace, podName) {
-      // simple unary call
       var request = new PodRequest({ podNamespace: podNamespace, podName: podName });
       const that = this;
 

--- a/src/components/protos/sk8l_connect.ts
+++ b/src/components/protos/sk8l_connect.ts
@@ -17,7 +17,7 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { CronjobPodsRequest, CronjobPodsResponse, CronjobRequest, CronjobResponse, CronjobsRequest, CronjobsResponse, CronjobYAMLResponse, JobRequest, JobYAMLResponse, PodRequest, PodYAMLResponse } from "./sk8l_pb.ts";
+import { CronjobPodsRequest, CronjobPodsResponse, CronjobRequest, CronjobResponse, CronjobsRequest, CronjobsResponse, CronjobYAMLResponse, DashboardAnnotationsRequest, DashboardAnnotationsResponse, JobRequest, JobYAMLResponse, PodRequest, PodYAMLResponse } from "./sk8l_pb.ts";
 import { MethodKind } from "@bufbuild/protobuf";
 
 /**
@@ -78,6 +78,15 @@ export const Cronjob = {
       name: "GetPodYAML",
       I: PodRequest,
       O: PodYAMLResponse,
+      kind: MethodKind.Unary,
+    },
+    /**
+     * @generated from rpc sk8l.Cronjob.GetDashboardAnnotations
+     */
+    getDashboardAnnotations: {
+      name: "GetDashboardAnnotations",
+      I: DashboardAnnotationsRequest,
+      O: DashboardAnnotationsResponse,
       kind: MethodKind.Unary,
     },
   }

--- a/src/components/protos/sk8l_pb.ts
+++ b/src/components/protos/sk8l_pb.ts
@@ -228,6 +228,74 @@ export class PodRequest extends Message<PodRequest> {
 }
 
 /**
+ * @generated from message sk8l.DashboardAnnotationsRequest
+ */
+export class DashboardAnnotationsRequest extends Message<DashboardAnnotationsRequest> {
+  constructor(data?: PartialMessage<DashboardAnnotationsRequest>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "sk8l.DashboardAnnotationsRequest";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): DashboardAnnotationsRequest {
+    return new DashboardAnnotationsRequest().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): DashboardAnnotationsRequest {
+    return new DashboardAnnotationsRequest().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): DashboardAnnotationsRequest {
+    return new DashboardAnnotationsRequest().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: DashboardAnnotationsRequest | PlainMessage<DashboardAnnotationsRequest> | undefined, b: DashboardAnnotationsRequest | PlainMessage<DashboardAnnotationsRequest> | undefined): boolean {
+    return proto3.util.equals(DashboardAnnotationsRequest, a, b);
+  }
+}
+
+/**
+ * @generated from message sk8l.DashboardAnnotationsResponse
+ */
+export class DashboardAnnotationsResponse extends Message<DashboardAnnotationsResponse> {
+  /**
+   * @generated from field: string annotations = 1;
+   */
+  annotations = "";
+
+  constructor(data?: PartialMessage<DashboardAnnotationsResponse>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "sk8l.DashboardAnnotationsResponse";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "annotations", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): DashboardAnnotationsResponse {
+    return new DashboardAnnotationsResponse().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): DashboardAnnotationsResponse {
+    return new DashboardAnnotationsResponse().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): DashboardAnnotationsResponse {
+    return new DashboardAnnotationsResponse().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: DashboardAnnotationsResponse | PlainMessage<DashboardAnnotationsResponse> | undefined, b: DashboardAnnotationsResponse | PlainMessage<DashboardAnnotationsResponse> | undefined): boolean {
+    return proto3.util.equals(DashboardAnnotationsResponse, a, b);
+  }
+}
+
+/**
  * @generated from message sk8l.CronjobsResponse
  */
 export class CronjobsResponse extends Message<CronjobsResponse> {


### PR DESCRIPTION
Add button on navigation bar to display the json based on cronjob definitions that can be copy-pasted in Grafana to create a base dashboard.