### PR TITLE
Release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,160 @@
+## v0.10.0 (April 24, 2024)
+
+ENHANCEMENTS:
+
+* ci/dependabot: Configure dependabot version updates [[GH-15](https://github.com/danroux/sk8l-ui/issues/15)]
+* ci/dependabot: docker deps:(deps): bump nginx from 1.25.3-alpine3.18-slim to 1.25.4-alpine3.18-slim
+
+docker deps:(deps): bump nginx
+
+Bumps nginx from 1.25.3-alpine3.18-slim to 1.25.4-alpine3.18-slim.
+
+---
+updated-dependencies:
+- dependency-name: nginx
+  dependency-type: direct:production
+  update-type: version-update:semver-patch
+...
+
+Signed-off-by: dependabot[bot] <support@github.com> [[GH-16](https://github.com/danroux/sk8l-ui/issues/16)]
+* ci/dependabot: docker deps:(deps): bump node from 20.5.1-bookworm-slim to 21.7.3-bookworm-slim
+
+docker deps:(deps): bump node
+
+Bumps node from 20.5.1-bookworm-slim to 21.7.3-bookworm-slim.
+
+---
+updated-dependencies:
+- dependency-name: node
+  dependency-type: direct:production
+  update-type: version-update:semver-major
+...
+
+Signed-off-by: dependabot[bot] <support@github.com> [[GH-18](https://github.com/danroux/sk8l-ui/issues/18)]
+* ci/dependabot: gha deps:(deps): bump actions/checkout from 4.1.1 to 4.1.2
+
+gha deps:(deps): bump actions/checkout from 4.1.1 to 4.1.2
+
+Bumps [actions/checkout](https://github.com/actions/checkout) from 4.1.1 to 4.1.2.
+- [Release notes](https://github.com/actions/checkout/releases)
+- [Changelog](https://github.com/actions/checkout/blob/main/CHANGELOG.md)
+- [Commits](https://github.com/actions/checkout/compare/v4.1.1...9bb56186c3b09b4f86b1c65136769dd318469633)
+
+---
+updated-dependencies:
+- dependency-name: actions/checkout
+  dependency-type: direct:production
+  update-type: version-update:semver-patch
+...
+
+Signed-off-by: dependabot[bot] <support@github.com> [[GH-32](https://github.com/danroux/sk8l-ui/issues/32)]
+* ci/dependabot: gha deps:(deps): bump azure/setup-helm from 4.1.0 to 4.2.0
+
+gha deps:(deps): bump azure/setup-helm from 4.1.0 to 4.2.0
+
+Bumps [azure/setup-helm](https://github.com/azure/setup-helm) from 4.1.0 to 4.2.0.
+- [Release notes](https://github.com/azure/setup-helm/releases)
+- [Changelog](https://github.com/Azure/setup-helm/blob/main/CHANGELOG.md)
+- [Commits](https://github.com/azure/setup-helm/compare/v4.1.0...v4.2.0)
+
+---
+updated-dependencies:
+- dependency-name: azure/setup-helm
+  dependency-type: direct:production
+  update-type: version-update:semver-minor
+...
+
+Signed-off-by: dependabot[bot] <support@github.com> [[GH-31](https://github.com/danroux/sk8l-ui/issues/31)]
+* ci/dependabot: npm deps:(deps): bump @grpc/grpc-js from 1.10.0 to 1.10.6
+
+npm deps:(deps): bump @grpc/grpc-js from 1.10.0 to 1.10.6
+
+Bumps [@grpc/grpc-js](https://github.com/grpc/grpc-node) from 1.10.0 to 1.10.6.
+- [Release notes](https://github.com/grpc/grpc-node/releases)
+- [Commits](https://github.com/grpc/grpc-node/compare/@grpc/grpc-js@1.10.0...@grpc/grpc-js@1.10.6)
+
+---
+updated-dependencies:
+- dependency-name: "@grpc/grpc-js"
+  dependency-type: direct:production
+  update-type: version-update:semver-patch
+...
+
+Signed-off-by: dependabot[bot] <support@github.com> [[GH-19](https://github.com/danroux/sk8l-ui/issues/19)]
+* ci/dependabot: npm deps:(deps): bump ip from 2.0.0 to 2.0.1
+
+npm deps:(deps): bump ip from 2.0.0 to 2.0.1
+
+Bumps [ip](https://github.com/indutny/node-ip) from 2.0.0 to 2.0.1.
+- [Commits](https://github.com/indutny/node-ip/compare/v2.0.0...v2.0.1)
+
+---
+updated-dependencies:
+- dependency-name: ip
+  dependency-type: indirect
+...
+
+Signed-off-by: dependabot[bot] <support@github.com> [[GH-37](https://github.com/danroux/sk8l-ui/issues/37)]
+* ci/dependabot: npm deps:(deps): bump vue-router from 4.2.5 to 4.3.0
+
+npm deps:(deps): bump vue-router from 4.2.5 to 4.3.0
+
+Bumps [vue-router](https://github.com/vuejs/router) from 4.2.5 to 4.3.0.
+- [Release notes](https://github.com/vuejs/router/releases)
+- [Commits](https://github.com/vuejs/router/compare/v4.2.5...v4.3.0)
+
+---
+updated-dependencies:
+- dependency-name: vue-router
+  dependency-type: direct:production
+  update-type: version-update:semver-minor
+...
+
+Signed-off-by: dependabot[bot] <support@github.com> [[GH-26](https://github.com/danroux/sk8l-ui/issues/26)]
+* ci/dependabot: npm deps:(deps): bump vue-router from 4.3.0 to 4.3.1
+
+npm deps:(deps): bump vue-router from 4.3.0 to 4.3.1
+
+Bumps [vue-router](https://github.com/vuejs/router) from 4.3.0 to 4.3.1.
+- [Release notes](https://github.com/vuejs/router/releases)
+- [Commits](https://github.com/vuejs/router/compare/v4.3.0...v4.3.1)
+
+---
+updated-dependencies:
+- dependency-name: vue-router
+  dependency-type: direct:production
+  update-type: version-update:semver-patch
+...
+
+Signed-off-by: dependabot[bot] <support@github.com> [[GH-33](https://github.com/danroux/sk8l-ui/issues/33)]
+* ci/dependabot: npm deps:(deps-dev): bump vite from 5.1.1 to 5.2.9
+
+npm deps:(deps-dev): bump vite from 5.1.1 to 5.2.9
+
+Bumps [vite](https://github.com/vitejs/vite/tree/HEAD/packages/vite) from 5.1.1 to 5.2.9.
+- [Release notes](https://github.com/vitejs/vite/releases)
+- [Changelog](https://github.com/vitejs/vite/blob/main/packages/vite/CHANGELOG.md)
+- [Commits](https://github.com/vitejs/vite/commits/v5.2.9/packages/vite)
+
+---
+updated-dependencies:
+- dependency-name: vite
+  dependency-type: direct:development
+  update-type: version-update:semver-minor
+...
+
+Signed-off-by: dependabot[bot] <support@github.com> [[GH-29](https://github.com/danroux/sk8l-ui/issues/29)]
+* gha/ci: Execute smoke tests on GHA/CI [[GH-28](https://github.com/danroux/sk8l-ui/issues/28)]
+* tests: Smoke tests: Test cronjob and pods pages [[GH-38](https://github.com/danroux/sk8l-ui/issues/38)]
+
+IMPROVEMENTS:
+
+* k8s: Update protobuf files for k8s v1.29.2 [[GH-36](https://github.com/danroux/sk8l-ui/issues/36)]
+
+BUG FIXES:
+
+* gha/docker: Remove branch name from .docker workflow for now [[GH-30](https://github.com/danroux/sk8l-ui/issues/30)]
+
 ## v0.9.0 (March 19, 2024)
 
 BUG FIXES:

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ help: ## This help.
 
 # Bump these on release
 VERSION_MAJOR ?= 0
-VERSION_MINOR ?= 9
+VERSION_MINOR ?= 10
 VERSION_PATCH ?= 0
 
 WITHOUT ?= $(VERSION_MAJOR).$(VERSION_MINOR).$(VERSION_PATCH)


### PR DESCRIPTION
ENHANCEMENTS:

* ci/dependabot: docker:(deps): bump nginx from 1.25.3-alpine3.18-slim to 1.25.4-alpine3.18-slim  [[GH-16](https://github.com/danroux/sk8l-ui/issues/16)]
* ci/dependabot: docker:(deps): bump node from 20.5.1-bookworm-slim to 21.7.3-bookworm-slim  [[GH-18](https://github.com/danroux/sk8l-ui/issues/18)]
* ci/dependabot: npm:(deps): bump @grpc/grpc-js from 1.10.0 to 1.10.6 [[GH-19](https://github.com/danroux/sk8l-ui/issues/19)]
* ci/dependabot: npm:(deps): bump ip from 2.0.0 to 2.0.1 [[GH-37](https://github.com/danroux/sk8l-ui/issues/37)]
* ci/dependabot: npm:(deps): bump vue-router from 4.2.5 to 4.3.0  [[GH-26](https://github.com/danroux/sk8l-ui/issues/26)]
* ci/dependabot: npm:(deps): bump vue-router from 4.3.0 to 4.3.1 [[GH-33](https://github.com/danroux/sk8l-ui/issues/33)]
* ci/dependabot: npm:(deps-dev): bump vite from 5.1.1 to 5.2.9 [[GH-29](https://github.com/danroux/sk8l-ui/issues/29)]
* gha/ci: Execute smoke tests on GHA/CI [[GH-28](https://github.com/danroux/sk8l-ui/issues/28)]
* tests: Smoke tests: Test cronjob and pods pages [[GH-38](https://github.com/danroux/sk8l-ui/issues/38)]

IMPROVEMENTS:

* k8s: Update protobuf files for k8s v1.29.2 [[GH-36](https://github.com/danroux/sk8l-ui/issues/36)]

BUG FIXES:

* gha/docker: Remove branch name from .docker workflow for now [[GH-30](https://github.com/danroux/sk8l-ui/issues/30)]