### PR TITLE
Improve multiarch image building process for pre/production

### DIFF
--- a/.changelog/214.txt
+++ b/.changelog/214.txt
@@ -1,0 +1,12 @@
+```release-note:improvement
+Docker: Improve multiarch(amd64,arm64) image building process for pre/production
+
+Migrate to mcr.microsoft.com/devcontainers/typescript-node image to build production images with support for x86-64, amd64, arm64 architectures
+as it includes Node.js, eslint, nvm, yarn, and the TypeScript compiler.
+
+More info: https://hub.docker.com/r/microsoft/devcontainers-typescript-node
+
+The previously used image came from: https://hub.docker.com/r/arm64v8/node/tags?name=20.14 but was missing some dependencies.
+
+Also remove arm/v8 as a supported architecture for now.
+```

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -115,7 +115,7 @@ jobs:
           file: production.dockerfile
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          platforms: linux/amd64, linux/arm64, linux/arm/v8
+          platforms: linux/amd64, linux/arm64
           push: true
           tags: |
             ${{ vars.GHCR_SK8L_UI_IMAGE_NAME }}:pre
@@ -146,7 +146,7 @@ jobs:
           file: production.dockerfile
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          platforms: linux/amd64, linux/arm64, linux/arm/v8
+          platforms: linux/amd64, linux/arm64
           push: true
           tags: |
             ${{ vars.GHCR_SK8L_UI_IMAGE_NAME }}:pre-${{ inputs.image_tag }}
@@ -174,7 +174,7 @@ jobs:
         with:
           context: .
           file: production.dockerfile
-          platforms: linux/amd64, linux/arm64, linux/arm/v8
+          platforms: linux/amd64, linux/arm64
           push: true
           tags: |
             ${{ vars.DOCKERHUB_SK8L_UI_IMAGE_NAME }}:latest

--- a/production.dockerfile
+++ b/production.dockerfile
@@ -1,7 +1,8 @@
 # https://hub.docker.com/_/node/tags?page=1&name=bookworm-slim <- look for vulnerabilities
 # https://github.com/primer/octicons/blob/main/package.json
 
-FROM --platform=${TARGETPLATFORM} arm64v8/node:20.14.0-alpine3.20 AS build-stage
+# https://hub.docker.com/r/microsoft/devcontainers-typescript-node
+FROM --platform=${TARGETPLATFORM} mcr.microsoft.com/devcontainers/typescript-node:20 AS build-stage
 
 ARG TARGETPLATFORM TARGETOS TARGETARCH
 ENV npm_config_cache=/usr/app/node_modules/.cache


### PR DESCRIPTION
Migrate to mcr.microsoft.com/devcontainers/typescript-node image to build production images with support for x86-64, amd64, arm64 architectures as it includes Node.js, eslint, nvm, yarn, and the TypeScript compiler.

More info: https://hub.docker.com/r/microsoft/devcontainers-typescript-node

The previously used image came from: https://hub.docker.com/r/arm64v8/node/tags?name=20.14 was missing some dependencies.

Also remove arm/v8 as a supported architecture for now.