### PR TITLE
Use node images with alpine for dev release on Dockerfile

### DIFF
--- a/.changelog/238.txt
+++ b/.changelog/238.txt
@@ -1,0 +1,5 @@
+```release-note:improvement
+Docker: Use node images with alpine for dev release on Dockerfile
+
+Do this to simplify Dockerfile
+```

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -52,8 +52,7 @@ jobs:
           file: Dockerfile
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          # platforms: linux/amd64,linux/arm64,linux/arm/v7
-          platforms: linux/amd64
+          platforms: linux/amd64, linux/arm64
           push: true
           tags: |
             ${{ vars.GHCR_SK8L_UI_IMAGE_NAME }}:dev-${{ inputs.image_tag }}
@@ -84,7 +83,7 @@ jobs:
           file: Dockerfile
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          platforms: linux/amd64
+          platforms: linux/amd64, linux/arm64
           push: true
           tags: |
             ${{ vars.GHCR_SK8L_UI_IMAGE_NAME }}:dev
@@ -182,7 +181,7 @@ jobs:
   sk8l-ui-test-img:
     runs-on: ubuntu-latest
     name: sk8l-ui:ui-test-${{ inputs.image_tag }}
-    needs: [sk8l-ui-pre-pr-img]
+    needs: [sk8l-ui-dev-img]
     if: ${{ github.event_name == 'workflow_call' && inputs.image_tag || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,6 @@
-# FROM node:18.16.0-alpine3.18
-
-# WORKDIR /usr/app
-# # COPY main.go /usr/app
-# RUN npm install -g sass
-# RUN npm install --save @primer/css
-# RUN sass --load-path=node_modules node_modules/@primer/css:/usr/app/here/stylesheets
-
-# CMD ["/bin/sh"]
-
 # https://hub.docker.com/_/node/tags?page=1&name=bookworm-slim <- look for vulnerabilities
 # https://github.com/primer/octicons/blob/main/package.json
 FROM node:22.3.0-bookworm-slim AS deps
-# FROM arm32v7/node:22.2.0-bookworm-slim AS deps
 
 RUN groupadd --system --gid 101 nginx \
     && useradd --system --gid nginx --create-home --home /home/nginx --comment "nginx user" --shell /bin/bash --uid 101 nginx \
@@ -20,18 +9,6 @@ RUN groupadd --system --gid 101 nginx \
 WORKDIR /home/nginx
 ENV npm_config_cache=/home/nginx/node_modules/.cache
 COPY package*.json yarn.lock .yarnrc.yml .
-# # COPY node_modules .
-# # USER 1000:3000
-# RUN npm install -g npm@10.2.2
-# # RUN npm ci --only=production
-# RUN npm install # needed to install ./node_modules/.bin/vue-cli-service
-# # RUN npm ci --omit=dev
-# # RUN npm ci
-
-# USER 101
-
-# $(pwd)/bin
-# corepack enable --install-directory ~/bin \
 
 RUN node -p "process.arch" \
     && echo $TARGETPLATFORM && echo $TARGETOS && echo $TARGETARCH
@@ -40,10 +17,7 @@ RUN mkdir -p $(pwd)/node_modules/.cache  \
     && yarn config set --home enableTelemetry 0 \
     && yarn install
 
-# # COPY package.json yarn.lock ./
-# # RUN yarn install --production
-
-FROM alpine:3.20 AS release
+FROM --platform=${TARGETPLATFORM} node:20.14.0-alpine3.20 AS release
 
 LABEL org.opencontainers.image.source=https://github.com/danroux/sk8l-ui
 LABEL org.opencontainers.image.description="sk8l-ui dev image"
@@ -51,23 +25,7 @@ LABEL org.opencontainers.image.licenses=MIT
 
 ARG TARGETPLATFORM TARGETOS TARGETARCH
 ENV npm_config_cache=/usr/app/node_modules/.cache
-# https://unofficial-builds.nodejs.org/download/release/v21.7.3/
-ENV V=20.14.0
-# ENV FILE node-v$V-linux-x64-musl.tar.xz
 WORKDIR /usr/app
-
-RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then FILE=x64-musl; elif [ "$TARGETPLATFORM" = "linux/arm/v8" ]; then FILE=armv6l; elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then FILE=armv6l; else FILE=x64-musl; fi \
-    && apk add --no-cache libstdc++ \
-    && apk add --no-cache --virtual .deps curl \
-    && curl -fsSLO --compressed \
-    "https://unofficial-builds.nodejs.org/download/release/v$V/node-v$V-linux-$FILE.tar.xz" \
-    && tar -xJf node-v$V-linux-$FILE.tar.xz -C /usr/local --strip-components=1 \
-    # ATTENTION!! --- maybe i want to remove this after all or add npm as a dep or sth. like that
-    # && rm -f $FILE /usr/local/bin/npm /usr/local/bin/npx \
-    # && rm -rf /usr/local/lib/node_modules \
-    && apk del .deps \
-    && rm node-v$V-linux-$FILE.tar.xz
-# RUN npm install -g npm@10.4.0
 
 # not actually needed locally, but to keep initContainer command working
 RUN mkdir -p /app_tmp/ \


### PR DESCRIPTION
Doing this to simplify Dockerfile...

Use `node:20.14.0-alpine3.20` instead of using `alpine:3.20` and installing `node`.